### PR TITLE
build(gradle): raise max RAM for build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2g
 project.version=1.0.0


### PR DESCRIPTION
Dokka fails on macOS to Out of Memory, this could fix problem